### PR TITLE
makes game boards realistic so edge cases don't pass

### DIFF
--- a/spec/game_status_spec.rb
+++ b/spec/game_status_spec.rb
@@ -30,49 +30,49 @@ describe "./lib/game_status.rb" do
     end
 
     it 'returns an array of matching indexes for a top row win' do
-      board = ["X", "X", "X", " ", " ", " ", " ", " ", " "]
+      board = ["X", "X", "X", "O", "O", " ", " ", " ", " "]
 
       expect(won?(board)).to match_array([0,1,2])
     end
 
     it 'returns an array of matching indexes for a middle row win' do
-      board = [" ", " ", " ", "X", "X", "X", " ", " ", " "]
+      board = ["O", "O", " ", "X", "X", "X", " ", " ", " "]
 
       expect(won?(board)).to match_array([3,4,5])
     end
 
     it 'returns an array of matching indexes for a bottom row win' do
-      board = [" ", " ", " ", " ", " ", " ", "X", "X", "X"]
+      board = [" ", " ", " ", "O", "O", " ", "X", "X", "X"]
 
       expect(won?(board)).to match_array([6,7,8])
     end
 
     it 'returns an array of matching indexes for a left column win' do
-      board = ["O", " ", " ", "O", " ", " ", "O", " ", " "]
+      board = ["O", " ", "X", "O", " ", "X", "O", " ", " "]
 
       expect(won?(board)).to match_array([0,3,6])
     end
 
     it 'returns an array of matching indexes for a middle column win' do
-      board = [" ", "O", " ", " ", "O", " ", " ", "O", " "]
+      board = ["X", "O", " ", "X", "O", " ", " ", "O", " "]
 
       expect(won?(board)).to match_array([1,4,7])
     end
 
     it 'returns an array of matching indexes for a right column win' do
-      board = [" ", " ", "O", " ", " ", "O", " ", " ", "O"]
+      board = ["X", " ", "O", "X", " ", "O", " ", " ", "O"]
 
       expect(won?(board)).to match_array([2,5,8])
     end
 
     it 'returns an array of matching indexes for a left diagonal win' do
-      board = ["X", " ", " ", " ", "X", " ", " ", " ", "X"]
+      board = ["X", " ", "O", " ", "X", "O", " ", " ", "X"]
 
       expect(won?(board)).to match_array([0,4,8])
     end
 
     it 'returns an array of matching indexes for a right diagonal win' do
-      board = [" ", " ", "O", " ", "O", " ", "O", " ", " "]
+      board = ["X", " ", "O", "X", "O", " ", "O", " ", " "]
 
       expect(won?(board)).to match_array([2,4,6])
     end


### PR DESCRIPTION
@aturkewi 

I was just working with a student whose `won?(board)` was only checking if the array of positions that were taken matched a winning combination (not whether they were all "X" or all "O") and all of her specs for `won?(board)` were passing. This was happening because the test cases only included 3 positions taken for each winning combo and they all were the same token. I've updated the specs so that they are at least possible game boards. This way, those specs won't pass if their code is only checking whether a position is taken.